### PR TITLE
Update dockerfile to build the war file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.data
+/target
+/build
+/out

--- a/README.md
+++ b/README.md
@@ -99,7 +99,23 @@ $ grails run-app
 ```
 
 
-## Run with Docker
+## Develop with Docker
+
+When developing with Docker, all the dependencies are included in docker images. No need to install anything on the host other than (docker)[https://docs.docker.com/engine/installation/]
+
+NOTE: This repo has submodules. If `--recursive` is not specified when cloning the repo, you need to run `git submodule update --init` to pull down the submodules.
+
+### Update configruation
+
+Update the following line in `catch-config.properties`:
+
+```
+dataSource.url=jdbc:mysql://localhost:3306/catch_test?useUnicode=yes&characterEncoding=UTF-8&autoReconnect=true
+```
+To
+```
+dataSource.url=jdbc:mysql://db:3306/catch?useUnicode=yes&characterEncoding=UTF-8&autoReconnect=true
+```
 
 ### Start application
 
@@ -108,6 +124,14 @@ docker-compose up -d
 ```
 
 Docker will download official MySQL image and build catcha image. Docker-compose will create a docker network and run both images. Once they are started, the application can be accessed at http://localhost:8080.
+
+Once the docker containers are running, you can make changes to the files on the host and they will be auto-reloaded.
+
+### Check logs
+
+```
+docker logs -f catch_app_1
+```
 
 ### Stop application
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: mysql:5.7
+    image: mariadb:10.1
     volumes:
       - "./.data/db:/var/lib/mysql"
     restart: always
@@ -12,9 +12,13 @@ services:
       MYSQL_PASSWORD: catch
   app:
     build: .
+    image: compass/catcha:latest
     depends_on:
       - db
     volumes:
-      - "./.data/app:/usr/local/tomcat/webapps/ROOT/uploads"
+      - ".:/app"
+      - "./.data/app:/app/web-app/uploads"
+      - ".data/cache:/root/.grails/ivy-cache"
     ports:
       - "8080:8080"
+


### PR DESCRIPTION
This change makes possible to build the docker image automatically on
DockerHub for each push. It also enables to run the image both in
development mode and production mode (default).

Also update the docker-compose and README

This PR is depending on #83 
